### PR TITLE
Remove line break from RSS title value.

### DIFF
--- a/api/feeds/models.py
+++ b/api/feeds/models.py
@@ -100,7 +100,11 @@ class ModelBase(db.Model):
 
         for key in keys:
             if getattr(self, key) != dic[key]:
-                setattr(self, key, dic[key])
+                if key == 'title':
+                    value = dic[key].replace('\n', '').replace('\r', '')
+                else:
+                    value = dic[key]
+                setattr(self, key, value)
                 updateRequired = True
 
         return updateRequired


### PR DESCRIPTION
Remove line break from RSS title value.

Title value can not contain line break in current spec, but some RSS feeds may contain line break. (Such as SUUMO and so on.)
If line break contains, RSS registration will fail.
